### PR TITLE
Not relying on local files, refactoring code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # novo-t2d
-Scripts for populating database
+Populating database for Novo Nordisk.
+
+## Requirements
+
+The `populate.py` script requires Python 3 with the `pymysql` and `requests` packages.
+
+## How to run
+
+Set the following environment variables to specify the MySQL database connection information:
+
+```
+# Name of host to connect to
+export NND_HOST=...
+
+# User to authenticate to
+export NND_USER=...
+
+# Password to authenticate with
+export NND_PASS=...
+
+# Port of MySQL server
+export NND_PORT=...
+
+# Database to use
+export NND_DB=...
+```
+
+Then, run the script:
+
+```
+python populate.py [--trembl] [--log LOGFILE]
+``` 
+
+Options:
+
+* `--trembl`: import TrEMBL/unreviewed proteins (default: disabled).
+* `--log FILE`: write log messages to *FILE* (default: log messages printed in console).
+

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export NND_DB=...
 Then, run the script:
 
 ```
-python populate.py [-t/--threads THREADS] [--debug]
+python populate.py [-t/--threads THREADS] [--verbose]
 ``` 
 
 Options:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # novo-t2d
+
 Populating database for Novo Nordisk.
 
 ## Requirements
@@ -29,11 +30,11 @@ export NND_DB=...
 Then, run the script:
 
 ```
-python populate.py [--trembl] [--log LOGFILE]
+python populate.py [-t/--threads THREADS] [--debug]
 ``` 
 
 Options:
 
-* `--trembl`: import TrEMBL/unreviewed proteins (default: disabled).
-* `--log FILE`: write log messages to *FILE* (default: log messages printed in console).
+* `-t/--threads`: maximum number of parallel threads used to call the InterPro REST API (default: 4).
+* `--verbose`: increase verbosity by showing progress.
 

--- a/python/populate.py
+++ b/python/populate.py
@@ -325,7 +325,7 @@ def get_kegg_protein(pid):
 # if not len(kegg_pathways):
 #   log.info("KEGG protein " + kegg_protein_id + ": no pathways")
   return [kegg_gene, kegg_protein_desc, kegg_pathways]
- 
+
 
 nnd_conn = nnd_db()
 
@@ -396,7 +396,7 @@ with urllib.request.urlopen("https://reactome.org/download/current/reactome_reac
     next(res) # Skip header
 
     for line in res:
-      fields = line.rstrip().split('\t')
+      fields = line.decode("utf-8").rstrip().split('\t')
       fields[-1] = fields[-1].replace('"', '')
       pathway_id = fields[0]
       reaction_id = fields[1]
@@ -529,13 +529,13 @@ with nnd_conn.cursor() as cursor:
 
     for pdb in protein.pdb:
       cursor.execute(pdb_sql, (protein.acc, pdb[0], pdb[1]))
-    
+
     for go in protein.go:
       cursor.execute(go_sql, (protein.acc, go[0], go[1], go[2]))
-    
+
     for cp in protein.complex_portal_xref:
       cursor.execute(complex_sql, (cp, protein.acc))
-    
+
     ip_proteins = get_ip_protein(protein.acc)
 
     # Load any InterPro entries ...
@@ -583,4 +583,3 @@ with nnd_conn.cursor() as cursor:
       sys.stdout.flush()
 
   log.info('Loaded: ' + str(count))
-

--- a/python/populate.py
+++ b/python/populate.py
@@ -97,9 +97,9 @@ class Protein(object):
 
 
 def get_args(args):
-    parser = argparse.ArgumentParser(prog = args[0])
-    parser.add_argument('-t', '--tr', action ='store_true', dest = 'trembl', required = False, help = 'Include TrEMBL')
-    parser.add_argument("-l", "--log", help = "log file", dest = "log", action = "store", required = False)
+    parser = argparse.ArgumentParser(prog=args[0])
+    parser.add_argument("--trembl", action="store_true", dest="trembl", required=False, help="Include TrEMBL")
+    parser.add_argument("--log", action="store", dest="log", required=False, help="log file")
     return vars(parser.parse_args())
 
 
@@ -502,7 +502,7 @@ with nnd_conn.cursor() as cursor:
 
   count = 0
   for protein in get_protein(9606, args['trembl']):
-    # Skip existing entires; may want to make this optional for speed?
+    # Skip existing entries; may want to make this optional for speed?
     if check_entry(cursor, 'protein', 'uniprot_acc', protein.acc):
       continue
     cursor.execute(protein_sql, (protein.acc, protein.id, protein.reviewed, ','.join(protein.genes), protein.name, str(protein.org_id), ';'.join(protein.enst_f), ';'.join(protein.complex_portal_xref), ';'.join(protein.reactome_xref), ';'.join(protein.kegg_xref), protein.secreted, ';'.join(protein.proteomes)))

--- a/python/populate.py
+++ b/python/populate.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
-import requests
-import time
-import logging
 import argparse
-import re
+import json
+import logging
 import os
+import re
 import sys
+import time
 import urllib.error
 import urllib.request
-import json
+
+import requests
 import pymysql
 
 

--- a/python/populate.py
+++ b/python/populate.py
@@ -2,584 +2,642 @@
 # -*- coding: utf-8 -*-
 
 import argparse
-import json
 import logging
 import os
 import re
-import sys
 import time
-import urllib.error
-import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib import request
 
-import requests
 import pymysql
-
-
-# Populate NovoNordisk database, pulling data from UniProt proteins API and other sources
-
-# Fixes needed:
-# - kegg.disease
-# - IPRs with multiple children (only one taken at present) - check query
-# - kegg_step via API - streamline?
-# - target - populate acc/source, possibly from second script
-# - auto generate schema?
-
-
-# Convenience class for unpacking the protein json string
-class Protein(object):
-  def __init__(self, obj):
-    self.acc = obj['accession']
-    self.id = obj['id']
-    self.org_id = obj['organism']['taxonomy']
-    self.reviewed = 1 if obj['info']['type'] == 'Swiss-Prot' else 0
-
-    self.genes = []
-    if 'gene' in obj:
-      for gene in obj['gene']:
-        if 'name' in gene:
-          self.genes.append(gene['name']['value'])
-
-    self.secreted = 0
-    if 'keywords' in obj:
-      for kw in obj['keywords']:
-        if kw['value'] in ['Signal', 'Secreted']:
-          self.secreted = 1
-          break
-
-    if 'recommendedName' in obj['protein']:
-      self.name = obj['protein']['recommendedName']['fullName']['value']
-    # submitted appears to be an array
-    elif 'submittedName' in obj['protein']:
-      self.name = obj['protein']['submittedName'][0]['fullName']['value']
-
-    self.enst = []
-    self.enst_f = [] # formatted version with isoform in []
-    self.complex_portal_xref = []
-    self.reactome_xref = []
-    self.kegg_xref = []
-    self.proteomes = []
-    self.ko = []
-    self.pdb = []
-    self.go = []
-    go_dict = {
-      'F': 'MF',
-      'C': 'CC',
-      'P': 'BP'
-    }
-    for db_ref in obj['dbReferences']:
-      if db_ref['type'] == 'Ensembl':
-        et = [ db_ref['id'] ]
-        etf = db_ref['id']
-        if 'isoform' in db_ref:
-          et.append(db_ref['isoform'])
-          etf = etf + ' [' + db_ref['isoform'] + ']'
-        else:
-          et.append('')
-        self.enst.append(et)
-        self.enst_f.append(etf)
-      elif db_ref['type'] == 'ComplexPortal':
-        self.complex_portal_xref.append(db_ref['id'])
-      elif db_ref['type'] == 'Reactome':
-        self.reactome_xref.append(db_ref['id'])
-      elif db_ref['type'] == 'KEGG':
-        self.kegg_xref.append(db_ref['id'])
-      elif db_ref['type'] == 'KO':
-        self.ko.append(db_ref['id'])
-      elif db_ref['type'] == 'Proteomes':
-        self.proteomes.append(db_ref['id'])
-      elif db_ref['type'] == 'PDB':
-        if 'chains' in db_ref['properties']:
-          chains = db_ref['properties']['chains'].split('=', maxsplit = 1)[0].split('/')
-          for chain in chains:
-            self.pdb.append([db_ref['id'], chain])
-      elif db_ref['type'] == 'GO':
-        go = db_ref['properties']['term'].split(':', maxsplit = 1)
-        self.go.append([db_ref['id'], go_dict[go[0]], go[1]])
-
-
-def get_args(args):
-    parser = argparse.ArgumentParser(prog=args[0])
-    parser.add_argument("--trembl", action="store_true", dest="trembl", required=False, help="Include TrEMBL")
-    parser.add_argument("--log", action="store", dest="log", required=False, help="log file")
-    return vars(parser.parse_args())
-
-
-ip_type_dict = {
-  'family': 'Family',
-  'domain': 'Domain',
-  'repeat': 'Repeat',
-  'conserved_site': 'conserved site',
-  'homologous_superfamily': 'Homologous Superfamily',
-  'active_site': 'active site',
-  'binding_site': 'binding site',
-  'ptm': 'PTM site',
-}
-
-
-def get_ip_entry(entry_acc):
-  url = 'https://www.ebi.ac.uk/interpro/api/entry/InterPro/%s' % (entry_acc)
-  entry = json.loads(get_url(url))['metadata']
-  entry_type = ip_type_dict[entry['type']]
-  entry_name = entry['name']['short']
-  num_proteins = entry['counters']['proteins']
-  children = entry['hierarchy']['children']
-  child = children[0]['accession'] if len(children) else ''
-  return [entry_acc, entry_type, entry_name, num_proteins, child, 1]
-
-
-def get_ip_protein(protein_acc):
-  url = 'https://www.ebi.ac.uk/interpro/api/protein/UniProt/%s/entry/InterPro?is_fragment=false' % (protein_acc)
-  res = get_url(url)
-  if not res:
-    return []
-  try:
-    res = json.loads(res)
-  except json.decoder.JSONDecodeError as e:
-    log.error("Error decoding InterPro response" + e)
-    sys.exit(1)
-  if not 'entry_subset' in res:
-    log.error("Missing 'entry_subset' field in json for URL " + url + ": " + str(res))
-    sys.exit(1)
-  entry_subsets = res['entry_subset']
-  entries = []
-  for entry_subset in entry_subsets:
-    for location in entry_subset['entry_protein_locations']:
-        entries.append([
-            entry_subset['accession'].upper(),
-            protein_acc,
-            min([f['start'] for f in location['fragments']]),
-            max([f['end'] for f in location['fragments']])
-        ])
-
-  return entries
-
-
-def insert_sql(table, columns): # Hardcoded column order, bad
-  sql = "INSERT INTO `%s`" % (table) + ' ('
-  sql += ','.join([ '`' + col + '`' for col in columns ])
-  sql += ') VALUES ('
-  sql += ','.join([ '%s' for col in columns ]) + ')'
-  return sql
-
-
-def version_columns():
-  return ['resource', 'version']
-
-
-def kegg_step_columns():
-  return ['kegg_pathway_id', 'uniprot_acc', 'kegg_protein', 'kegg_gene', 'kegg_protein_desc']
-
-
-def kegg_columns(): # Description and disease are missing
-  return ['kegg_pathway_id', 'description', 'number_steps', 'kegg_disease']
-
-
-def reactome_columns():
-  return ['pathway_id', 'description', 'species', 'number_steps']
-
-
-def reactome_step_columns():
-  return ['pathway_id', 'reaction_id', 'reaction_name', 'uniprot_acc', 'reaction_role']
-
-
-def interpro_match_columns():
-  return ['interpro_acc', 'uniprot_acc', 'start', 'end']
-
-
-def interpro_columns():
-  return ['interpro_acc', 'ipr_type', 'short_name', 'num_matches', 'child_interpro_acc', 'checked']
-
-
-def complex_portal_columns():
-  return ['complex_portal_accession', 'description', 'number_proteins']
-
-
-def protein_columns():
-  return ['uniprot_acc', 'uniprot_id', 'reviewed',
-    'gene_name', 'description', 'species', 'ensembl_gene',
-    'complex_portal_xref', 'reactome_xref', 'kegg_xref', 'secreted', 'proteome']
-
-
-def go_columns():
-  return ['uniprot_acc', 'go_id', 'go_class', 'go_name']
-
-
-def complex_component_columns():
-  return ['complex_portal_accession', 'uniprot_acc']
-
-
-def pdb_columns():
-  return ['uniprot_acc', 'pdb_id', 'chain']
-
-
-def ortholog_columns():
-  return ['uniprot_acc', 'ortholog_uniprot_acc', 'species']
-
-
-def ensembl_columns():
-  return ['uniprot_acc', 'uniprot_isoform', 'ensembl_transcript_acc']
-
-
-def check_entry(cursor, table, column, value):
-  cursor.execute('select count(*) from ' + table + ' where ' + column + ' = %s', (value))
-  return cursor.fetchone()['count(*)']
-
-
-def count_table_rows(cursor, table):
-  cursor.execute('select count(*) from ' + table)
-  return cursor.fetchone()['count(*)']
-
-
-def nnd_db():
-  return pymysql.connect(host        = os.getenv('NND_HOST'),
-                         user        = os.getenv('NND_USER'),
-                         password    = os.getenv('NND_PASS'),
-                         port        = int(os.getenv('NND_PORT')),
-                         db          = os.getenv('NND_DB'),
-                         charset     = 'utf8',
-                         cursorclass = pymysql.cursors.DictCursor)
-
-
-def get_protein(taxon, trembl, max = -1): # Max for testing purposes
-  offset = 0
-  count = 0
-  batch = 500
-  while True:
-    if trembl:
-      url = "https://www.ebi.ac.uk/proteins/api/proteins?size=%d&isoform=0&taxid=%d&offset=%d" % (batch, taxon, offset)
-    else:
-      url = "https://www.ebi.ac.uk/proteins/api/proteins?size=%d&isoform=0&taxid=%d&reviewed=true&offset=%d" % (batch, taxon, offset)
-    try:
-      data = get_url(url)
-    except requests.exceptions.HTTPError as e:
-      # in case of failure, likely an API timeout: gradually reduce the batch size
-      if batch == 500:
-        batch = 10
-        continue
-      if batch == 10:
-        batch = 1
-        continue
-      log.error("Error retrieving UniProt entry from URL " + url)
-      sys.exit(1)
-    entries = json.loads(data)
-    data = None
-    if len(entries) == 0:
-      return
-    for entry in entries:
-      if count >= max >= 0:
-        return
-      count += 1
-      yield Protein(entry)
-    offset += batch
-    # reset batch size
-    if offset % 500 == 0:
-      batch = 500
-    elif offset % 10 == 0 and batch != 500:
-      batch = 10
-
-
-def get_url(url):
-  attempt = 0
-  while attempt <= 3:
-    try:
-      r = requests.get(url, headers = { "Accept" : "application/json"}, timeout = 30)
-      r.encoding = 'utf8'
-      if not r.ok:
-        raise requests.exceptions.HTTPError
-      return r.text
-    except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError, requests.exceptions.ReadTimeout) as e:
-      attempt += 1
-      time.sleep(3)
-  raise requests.exceptions.HTTPError("Error retrieving " + url)
-
-
-def get_kegg_protein(pid):
-  try:
-    kegg_entry = get_url('http://rest.kegg.jp/get/%s' % (pid)).rstrip('\n').split('\n')
-  except urllib.error.HTTPError as e:
-    if str(e) == 'HTTP Error 404: Not Found':
-      return []
-  kegg_gene = kegg_protein_desc = None # Check: some KEGG entries are not complete
-  kegg_pathways = []
-  for line in kegg_entry:
-    if line.startswith('NAME'):
-      m = re.match('NAME\s+(\w+),?', line)
-      kegg_gene = m.group(1)
-    elif line.startswith('DEFINITION'):
-      m = re.match('DEFINITION\s+\(\w+\)\s+(.*)', line)
-      kegg_protein_desc = m.group(1)
-    elif line.startswith('PATHWAY'):
-      m = re.match('PATHWAY\s+(\w+)', line)
-      kegg_pathways.append(m.group(1))
-    elif len(kegg_pathways):
-      # have reached pathway lines: handle remaining entries
-      if line[0] != ' ':
-        break
-      m = re.match('\s+(\w+)', line)
-      kegg_pathways.append(m.group(1))
-  # TODO: should we permit KEGG entries without genes/descriptions?
-  if len(kegg_pathways) and not kegg_gene:
-    log.info("KEGG protein " + kegg_protein_id + ": no gene name")
-  if len(kegg_pathways) and not kegg_protein_desc:
-    log.info("KEGG protein " + kegg_protein_id + ": no description")
-# if not len(kegg_pathways):
-#   log.info("KEGG protein " + kegg_protein_id + ": no pathways")
-  return [kegg_gene, kegg_protein_desc, kegg_pathways]
-
-
-nnd_conn = nnd_db()
-
-# Table: versions
-
-args = get_args(sys.argv)
-
-log = logging.getLogger()
-log.setLevel(logging.INFO)
-if args['log']:
-  handler = logging.FileHandler(args['log'])
-else:
-  handler = logging.StreamHandler()
-handler.setFormatter(logging.Formatter('%(asctime)s: %(message)s', "%Y-%m-%d %H:%M:%S"))
-log.addHandler(handler)
-
-cp_versions = urllib.request.urlopen('ftp://ftp.ebi.ac.uk/pub/databases/intact/complex/').read().decode('utf-8').rstrip('\n').replace('\r','').split('\n')
-for line in cp_versions:
-  m = re.match('.*current -> (\d{4}-\d{2}-\d{2})', line)
-  if m:
-    cp_version = m.group(1)
-    break
-
-ukb = urllib.request.urlopen('ftp://ftp.ebi.ac.uk/pub/databases/uniprot/current_release/relnotes.txt').read().decode('utf-8').rstrip('\n')
-m = re.match('UniProt Release (\d{4}_\d{2})', ukb)
-if m:
-  ukb_version = m.group(1)
-
-kegg_info = get_url('http://rest.kegg.jp/info/kegg').rstrip('\n').split('\n')
-for line in kegg_info:
-  m = re.match('.*Release\s+(.*)', line)
-  if m:
-    kegg_version = m.group(1)
-    break
-
-reactome_version = urllib.request.urlopen("https://reactome.org/ContentService/data/database/version").read().decode("utf-8").strip()
-interpro_version = urllib.request.urlopen("https://www.ebi.ac.uk/interpro/api/").info()["InterPro-Version"].strip()
-
-with nnd_conn.cursor() as cursor:
-  version_sql = insert_sql('versions', version_columns())
-  cursor.execute('delete from versions')
-  cursor.execute(version_sql, ('Complex portal', cp_version))
-  cursor.execute(version_sql, ('UniProtKB', ukb_version))
-  cursor.execute(version_sql, ('KEGG', kegg_version))
-  cursor.execute(version_sql, ('Reactome', reactome_version))
-  cursor.execute(version_sql, ('InterPro', interpro_version))
-  nnd_conn.commit()
-
-# Pull orthologs and reactome reactions now as it's quicker to get for
-# all proteins
-
-# Get orthologs
-
-orthologs = {}
-for orth_species in [10090, 10116]:
-  for protein in get_protein(orth_species, args['trembl']):
-    for ko in protein.ko:
-      if not ko in orthologs:
-        orthologs[ko] = []
-      orthologs[ko].append([protein.acc, protein.org_id])
-  log.info("Obtained orthologs for " + str(orth_species))
-
-# Get reactome reactions
-
-reactions = {}
-reactome_steps = {}
-with urllib.request.urlopen("https://reactome.org/download/current/reactome_reaction_exporter_v{}.txt".format(reactome_version)) as res:
-    next(res) # Skip header
-
-    for line in res:
-      fields = line.decode("utf-8").rstrip().split('\t')
-      fields[-1] = fields[-1].replace('"', '')
-      pathway_id = fields[0]
-      reaction_id = fields[1]
-      reaction_name = fields[2]
-      uniprot_acc = fields[3]
-      reaction_role = fields[4][1:-1]  # trim leading/trailing square brackets
-
-      try:
-        reactions[uniprot_acc].append((pathway_id, reaction_id, reaction_name,
-                                       uniprot_acc, reaction_role))
-      except KeyError:
-        reactions[uniprot_acc] = [(pathway_id, reaction_id, reaction_name,
-                                   uniprot_acc, reaction_role)]
-
-      try:
-        reactome_steps[pathway_id].add(reaction_id)
-      except KeyError:
-        reactome_steps[pathway_id] = {reaction_id}
-
-log.info("Obtained reactome reactions")
-
-# Populate tables which don't link directly to protein:
-# complex_portal, kegg, reactome
-
-# Table: complex_portal
-
-cp = urllib.request.urlopen('ftp://ftp.ebi.ac.uk/pub/databases/intact/complex/current/complextab/homo_sapiens.tsv').read().decode('utf-8').rstrip('\n').split('\n')
-complex_sql = insert_sql('complex_portal', complex_portal_columns())
-with nnd_conn.cursor() as cursor:
-  # Skip if already filled, or delete?
-  if not count_table_rows(cursor, 'complex_portal'):
-    for line in cp:
-      if line.startswith('#Complex ac'):
-        continue
-      f = line.split('\t')
-      cursor.execute(complex_sql, (f[0], f[1], 1 + f[4].count('|')))
-    nnd_conn.commit()
-log.info("Done table complex_portal")
-
-# Table: kegg
-
-kegg_desc = {}
-keggs = get_url('http://rest.kegg.jp/list/pathway').rstrip('\n').split('\n')
-# Get descriptions
-for line in keggs:
-  acc, desc = line.rstrip('\n').split('\t', maxsplit = 1)
-  acc = acc.replace('path:map', 'hsa') # Yuk, check API to see if there's a better way
-  kegg_desc[acc] = desc
-
-keggs = get_url('http://rest.kegg.jp/link/hsa/pathway').rstrip('\n').split('\n')
-kegg_counts = {}
-kegg_sql = insert_sql('kegg', kegg_columns())
-with nnd_conn.cursor() as cursor:
-  for line in keggs:
-    acc, step = line.split('\t')
-    acc = acc.replace('path:', '')
-    # Skip if already have this accession
-    if check_entry(cursor, 'kegg', 'kegg_pathway_id', acc):
-      continue
-    if not acc in kegg_counts:
-      kegg_counts[acc] = 0
-    kegg_counts[acc] += 1
-  for kegg in kegg_counts:
-    if not kegg in kegg_desc:
-      log.info("No description for " + kegg + "\n")
-      kegg_desc[kegg] = ''
-    cursor.execute(kegg_sql, (kegg, kegg_desc[kegg], kegg_counts[kegg], ""))
-  nnd_conn.commit()
-log.info("Done table kegg")
-
-# Table: reactome
-
-reactome_sql = insert_sql('reactome', reactome_columns())
-with nnd_conn.cursor() as cursor:
-  if not count_table_rows(cursor, 'reactome'):
-    reactomes = set()
-    reactome = get_url('https://reactome.org/download/current/UniProt2Reactome.txt').rstrip('\n').split('\n')
-    for line in reactome:
-      f = line.split('\t')
-      if f[5] != 'Homo sapiens':
-        continue
-      r = (f[1], f[3], f[5], len(reactome_steps[f[1]]))
-      if not r in reactomes:
-        reactomes.add(r)
-
-    for r in reactomes:
-      cursor.execute(reactome_sql, r)
-    nnd_conn.commit()
-log.info("Done table reactome")
-
-# Fill protein and all other tables that hang off it
-
-with nnd_conn.cursor() as cursor:
-  nnd_conn.ping(reconnect = True)
-  protein_sql = insert_sql('protein', protein_columns())
-  kegg_step_sql = insert_sql('kegg_step', kegg_step_columns())
-  reactome_step_sql = insert_sql('reactome_step', reactome_step_columns())
-  go_sql = insert_sql('gene_ontology', go_columns())
-  ensembl_sql = insert_sql('ensembl_transcript', ensembl_columns())
-  complex_sql = insert_sql('complex_component', complex_component_columns())
-  pdb_sql = insert_sql('pdb', pdb_columns())
-  ortholog_sql = insert_sql('ortholog', ortholog_columns())
-  interpro_sql = insert_sql('interpro', interpro_columns())
-  match_sql = insert_sql('interpro_match', interpro_match_columns())
-
-  ip_loaded = set()
-
-  count = 0
-  for protein in get_protein(9606, args['trembl']):
-    # Skip existing entries; may want to make this optional for speed?
-    if check_entry(cursor, 'protein', 'uniprot_acc', protein.acc):
-      continue
-    cursor.execute(protein_sql, (protein.acc, protein.id, protein.reviewed, ','.join(protein.genes), protein.name, str(protein.org_id), ';'.join(protein.enst_f), ';'.join(protein.complex_portal_xref), ';'.join(protein.reactome_xref), ';'.join(protein.kegg_xref), protein.secreted, ';'.join(protein.proteomes)))
-    count += 1
-
-    for enst in protein.enst:
-      cursor.execute(ensembl_sql, (protein.acc, enst[1], enst[0]))
-
-    if protein.acc in reactions:
-      for reaction in reactions[protein.acc]:
-        cursor.execute(reactome_step_sql, reaction)
-
-    protein_orthologs = set() # Account for identical orthologs mapping > once via different KOs
-    for ko in protein.ko:
-      if ko in orthologs:
-        for ortholog in orthologs[ko]:
-          protein_orthologs.add((protein.acc, ortholog[0], ortholog[1]))
-    for po in protein_orthologs:
-      cursor.execute(ortholog_sql, po)
-
-    for pdb in protein.pdb:
-      cursor.execute(pdb_sql, (protein.acc, pdb[0], pdb[1]))
-
-    for go in protein.go:
-      cursor.execute(go_sql, (protein.acc, go[0], go[1], go[2]))
-
-    for cp in protein.complex_portal_xref:
-      cursor.execute(complex_sql, (cp, protein.acc))
-
-    ip_proteins = get_ip_protein(protein.acc)
-
-    # Load any InterPro entries ...
-    for ip_protein in ip_proteins:
-      if ip_protein[0] in ip_loaded:
-        continue
-      if check_entry(cursor, 'interpro', 'interpro_acc', ip_protein[0]):
-        ip_loaded.add(ip_protein[0])
-        continue
-      entry = get_ip_entry(ip_protein[0])
-      cursor.execute(interpro_sql, entry)
-      ip_loaded.add(ip_protein[0])
-
-    # ... followed by the matches themselves
-    for ip_protein in ip_proteins:
-      cursor.execute(match_sql, ip_protein)
-
-    kegg_proteins = {}
-
-    # kegg_step
-    res = get_url('http://rest.kegg.jp/conv/genes/up:%s' % (protein.acc)).rstrip('\n')
-    if res:
-      kegg_protein_ids = res.split('\n')
-      # Convert UKB acc to kegg protein acc
-      for kegg_protein_id in kegg_protein_ids:
-        kegg_protein_id = kegg_protein_id.split('\t')[1] # above returns two IDs; skip the first [UKB] accession
-        # This API call seems slow, esp when we might loop over TrEMBL
-        if not kegg_protein_id in kegg_proteins:
-          entry = get_kegg_protein(kegg_protein_id)
-          if len(entry) == 0:
-            log.info("KEGG protein " + kegg_protein_id + " not found")
+import requests
+
+logging.basicConfig(format="%(asctime)s: %(message)s",
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    level=logging.INFO)
+logger = logging.getLogger("nnd")
+
+
+def fetch(url):
+    return request.urlopen(url).read().decode("utf-8")
+
+
+def fetch_complex_version():
+    data = fetch("ftp://ftp.ebi.ac.uk/pub/databases/intact/complex/")
+    for line in data.split('\n'):
+        m = re.search("current\s*->\s*(\d{4}-\d{2}-\d{2})", line)
+        if m:
+            return m.group(1)
+
+    raise RuntimeError("could not detect Complex Portal version")
+
+
+def fetch_kegg_version():
+    data = fetch("http://rest.kegg.jp/info/kegg")
+    for line in data.split('\n'):
+        m = re.search("Release\s*(.+)", line.strip())
+        if m:
+            return m.group(1)
+
+    raise RuntimeError("could not detect KEGG version")
+
+
+def fetch_reactome_version():
+    data = fetch("https://reactome.org/ContentService/data/database/version")
+    return data.strip()
+
+
+def fetch_uniprot_version():
+    data = fetch("ftp://ftp.ebi.ac.uk/pub/databases/uniprot/current_release/relnotes.txt")
+    m = re.search('UniProt Release (\d{4}_\d{2})', data)
+    if m:
+        return m.group(1)
+
+    raise RuntimeError("could not detect UniProtKB version")
+
+
+class UniProtEntry(object):
+    def __init__(self, obj):
+        self.accession = obj["accession"]
+        self.identifer = obj["id"]
+        self.taxid = obj["organism"]["taxonomy"]
+        self.is_reviewed = obj["info"]["type"] == "Swiss-Prot"
+        self.genes = []
+        for g in obj.get("gene", []):
+            try:
+                name = g["name"]["value"]
+            except (KeyError, TypeError):
+                continue
+            else:
+                self.genes.append(name)
+
+        self.is_secreted = False
+        for kw in obj.get("keywords", []):
+            if kw["value"] in ("Signal", "Secreted"):
+                self.is_secreted = True
+                break
+
+        self.name = self.select_name(obj["protein"])
+        if self.name is None:
+            raise ValueError("could not find a name for {}".format(self.accession))
+
+        self.xrefs = {
+            "ComplexPortal": [],
+            "Ensembl": [],
+            "GO": [],
+            "KEGG": [],
+            "KO": [],
+            "PDB": [],
+            "Proteomes": [],
+            "Reactome": []
+        }
+        for ref in obj.get("dbReferences", []):
+            ref_type = ref["type"]
+
+            if ref_type in ("ComplexPortal", "KEGG", "KO", "Proteomes", "Reactome"):
+                self.xrefs[ref["type"]].append(ref["id"])
+            elif ref_type == "Ensembl":
+                self.xrefs[ref_type].append((ref["id"], ref.get("isoform")))
+            elif ref_type == "GO":
+                # e.g. P:immune response
+                aspect, name = ref["properties"]["term"].split(':', maxsplit=1)
+                if aspect == 'C':
+                    aspect = "CC"
+                elif aspect == 'F':
+                    aspect = "MF"
+                else:  # should be 'P'
+                    aspect = "BP"
+                self.xrefs[ref_type].append((ref["id"], aspect, name))
+            elif ref_type == "PDB":
+                try:
+                    chains = ref["properties"]["chains"]
+                except (KeyError, TypeError):
+                    continue
+                else:
+                    # e.g. D/I=20-109
+                    for chain in chains.split('=', 1)[0].split('/'):
+                        self.xrefs[ref_type].append((ref["id"], chain))
+
+    @staticmethod
+    def select_name(obj):
+        try:
+            return obj["recommendedName"]["fullName"]["value"]
+        except (KeyError, TypeError):
+            pass
+
+        try:
+            return obj["submittedName"][0]["fullName"]["value"]
+        except (KeyError, IndexError, TypeError):
+            pass
+
+        return None
+
+    @property
+    def ensembl(self):
+        references = []
+        for transcript_id, isoform in self.xrefs["Ensembl"]:
+            if isoform:
+                references.append("{} [{}]".format(transcript_id, isoform))
+            else:
+                references.append(transcript_id)
+        return references
+
+    def astuple(self):
+        return (
+            self.accession,
+            self.identifer,
+            1 if self.is_reviewed else 0,
+            ','.join(self.genes),
+            self.name,
+            str(self.taxid),
+            ';'.join(self.ensembl),
+            ';'.join(self.xrefs["ComplexPortal"]),
+            ';'.join(self.xrefs["Reactome"]),
+            ';'.join(self.xrefs["KEGG"]),
+            1 if self.is_secreted else 0,
+            ';'.join(self.xrefs["Proteomes"])
+        )
+
+
+def fetch_uniprot(taxid, size=100):
+    default_size = size
+    url = "https://www.ebi.ac.uk/proteins/api/proteins"
+    offset = 0
+    while True:
+        params = {
+            "offset": offset,
+            "isoform": 0,
+            "taxid": taxid,
+            "size": size
+        }
+
+        r = requests.get(url, params=params, headers={"Accept": "application/json"})
+        if r.status_code == 500 and size > 1:
+            size = max(1, size//2)
             continue
-          kegg_proteins[kegg_protein_id] = entry
-        kegg_gene = kegg_proteins[kegg_protein_id][0]
-        kegg_protein_desc = kegg_proteins[kegg_protein_id][1]
-        kegg_pathways = kegg_proteins[kegg_protein_id][2]
-        for kegg_pathway in kegg_pathways:
-          cursor.execute(kegg_step_sql, (kegg_pathway, protein.acc, kegg_protein_id, kegg_gene, kegg_protein_desc))
 
-    nnd_conn.commit()
+        entries = r.json()
+        if not entries:
+            break
 
-    if not count % 1000:
-      # May want to make this output an option?
-      log.info('Loaded: ' + str(count))
-      sys.stdout.flush()
+        for obj in entries:
+            yield UniProtEntry(obj)
 
-  log.info('Loaded: ' + str(count))
+        offset += len(entries)
+        size = default_size
+
+
+def fetch_complex_data():
+    url = "ftp://ftp.ebi.ac.uk/pub/databases/intact/complex/current/complextab/homo_sapiens.tsv"
+    data = fetch(url)
+    lines = iter(data.rstrip().split('\n'))
+    next(lines)  # skip header
+    for line in lines:
+        fields = line.split('\t')
+        accession = fields[0]
+        recommended_name = fields[1]
+        molecules = fields[4].split('|')
+        identifers = []
+
+        for item in molecules:
+            # Format: identifer(stoichiometry), e.g. P10415(1)
+            identifers.append(re.match("(.+)\(\d+\)$", item).group(1))
+
+        yield accession, recommended_name, len(molecules), set(identifers)
+
+
+def fetch_kegg_data():
+    url = "http://rest.kegg.jp/conv/uniprot/hsa"
+    r = requests.get(url, stream=True)
+    kegg2uniprot = {}
+    for line in r.iter_lines(decode_unicode=True):
+        m = re.match("(hsa:\d+)\s+up:([A-Z0-9]+)", line)
+        hsa, up = m.groups()
+
+        try:
+            kegg2uniprot[hsa].add(up)
+        except KeyError:
+            kegg2uniprot[hsa] = {up}
+
+    url = "http://rest.kegg.jp/list/hsa"
+    r = requests.get(url, stream=True)
+    proteins = {}
+    for line in r.iter_lines(decode_unicode=True):
+        hsa, info = line.rstrip().split('\t')
+        try:
+            genes, desc = info.split(';')
+        except ValueError:
+            continue
+
+        gene = genes.split(',')[0].strip()
+        desc = desc.strip()
+
+        for up in kegg2uniprot.get(hsa, []):
+            try:
+                proteins[hsa].append((gene, desc, up))
+            except KeyError:
+                proteins[hsa] = [(gene, desc, up)]
+
+    url = "http://rest.kegg.jp/link/hsa/pathway"
+    r = requests.get(url, stream=True)
+    links = {}
+    for line in r.iter_lines(decode_unicode=True):
+        pathway_id, hsa = line.split('\t')
+        try:
+            links[pathway_id].add(hsa)
+        except KeyError:
+            links[pathway_id] = {hsa}
+
+    url = "http://rest.kegg.jp/list/pathway/hsa"
+    r = requests.get(url, stream=True)
+    descriptions = {}
+    for line in r.iter_lines(decode_unicode=True):
+        pathway_id, description = line.split('\t')
+        descriptions[pathway_id] =re.sub("\s*-\s*Homo sapiens \(human\)", "", description)
+
+    pathways = []
+    for pathway_id, pathway_proteins in links.items():
+        steps = []
+        for hsa in pathway_proteins:
+            for gene, desc, up in proteins.get(hsa, []):
+                steps.append((up, hsa, gene, desc))
+
+        pathways.append((
+            re.sub("^path:", "", pathway_id),
+            descriptions.get(pathway_id, ""),
+            len(pathway_proteins),
+            None,
+            steps
+        ))
+
+    return pathways
+
+
+def fetch_orthologs(taxids):
+    orthologs = {}
+    for taxid in taxids:
+        for p in fetch_uniprot(taxid):
+            for koid in p.xrefs["KO"]:
+                try:
+                    orthologs[koid].append((p.accession, p.taxid))
+                except KeyError:
+                    orthologs[koid] = [(p.accession, p.taxid)]
+
+    return orthologs
+
+
+def fetch_reactome_reactions(version):
+    url = "https://reactome.org/download/current/reactome_reaction_exporter_v{}.txt".format(version)
+    r = requests.get(url, stream=True)
+    lines = r.iter_lines(decode_unicode=True)
+    next(lines)  # skip header
+
+    reactions = {}
+    for line in lines:
+        fields = line.split('\t')
+        pathway_id = fields[0]
+        reaction_id = fields[1]
+        reaction_name = fields[2]
+        uniprot_acc = fields[3]
+        reaction_role = fields[4][1:-1]  # trim leading/trailing square brackets
+
+        try:
+            obj = reactions[uniprot_acc]
+        except KeyError:
+            obj = reactions[uniprot_acc] = []
+        finally:
+            obj.append((pathway_id, reaction_id, reaction_name, reaction_role))
+
+    return reactions
+
+
+def fetch_reactome_pathways(reactions):
+    reactome_steps = {}
+    for uniprot_reactions in reactions.values():
+        for pathway_id, reaction_id, reaction_name, reaction_role in uniprot_reactions:
+            try:
+                obj = reactome_steps[pathway_id]
+            except KeyError:
+                obj = reactome_steps[pathway_id] = set()
+            finally:
+                obj.add(reaction_id)
+
+    url = "https://reactome.org/download/current/UniProt2Reactome.txt"
+    r = requests.get(url, stream=True)
+    pathways = {}
+    for line in r.iter_lines(decode_unicode=True):
+        fields = line.split('\t')
+        # uniprot_acc = fields[0]``
+        pathway_id = fields[1]
+        description = fields[3]
+        species = fields[5]
+
+        """
+        Since a pathway can be linked to multiple UniProt entries,
+        we need to ensure that each pathway is returned only once.
+        """
+        if pathway_id in pathways or species != "Homo sapiens":
+            continue
+
+        pathways[pathway_id] = (
+            pathway_id,
+            description,
+            len(reactome_steps[pathway_id]),
+            species
+        )
+
+    return list(pathways.values())
+
+
+def find_node(node, key):
+    if node["accession"] == key:
+        return node
+
+    for child in node["children"]:
+        res = find_node(child, key)
+        if res:
+            return res
+
+    return None
+
+
+def fetch_interpro_entry(accession):
+    url = "https://www.ebi.ac.uk/interpro/api/entry/InterPro/{}".format(accession)
+    while True:
+        r = requests.get(url)
+        if r.status_code == 200:
+            entry = r.json()
+            metadata = entry["metadata"]
+
+            entry_type = {
+                "family": "Family",
+                "domain": "Domain",
+                "repeat": "Repeat",
+                "conserved_site": "conserved site",
+                "homologous_superfamily": "Homologous Superfamily",
+                "active_site": "active site",
+                "binding_site": "binding site",
+                "ptm": "PTM site"
+            }[metadata["type"]]
+
+            node = find_node(metadata["hierarchy"], accession)
+            try:
+                child = node["children"][0]["accession"]
+            except IndexError:
+                child = None
+
+            return (
+                metadata["accession"],
+                entry_type,
+                metadata["name"]["short"],
+                metadata["counters"]["proteins"],
+                child,
+                1
+            )
+        elif r.status_code == 408:
+            time.sleep(10)
+        else:
+            raise RuntimeError(url)
+
+
+def fetch_interpro_version():
+    while True:
+        r = requests.get("https://www.ebi.ac.uk/interpro/api/")
+
+        try:
+            return r.headers["InterPro-Version"]
+        except KeyError:
+            time.sleep(5)
+
+
+def fetch_interpro_entries():
+    entries = []
+    url = "https://www.ebi.ac.uk/interpro/api/entry/InterPro"
+    while True:
+        r = requests.get(url)
+
+        try:
+            data = r.json()
+            results = data["results"]
+        except (KeyError, ValueError):
+            time.sleep(5)
+        else:
+            for entry in data["results"]:
+                entries.append(entry["metadata"]["accession"])
+
+            url = data["next"]
+            if url is None:
+                break
+
+    return entries
+
+
+def fetch_interpro_matches(uniprot_acc):
+    url = "https://www.ebi.ac.uk/interpro/api/protein/UniProt/{}/entry/InterPro".format(uniprot_acc)
+    r = requests.get(url)
+    if r.status_code == 200:
+        data = r.json()
+        entries = []
+        for entry in data["entry_subset"]:
+            locations = []
+            for loc in entry["entry_protein_locations"]:
+                locations.append((
+                    loc["fragments"][0]["start"],
+                    loc["fragments"][0]["end"]
+                ))
+
+            entries.append((entry["accession"], locations))
+
+        return entries
+    elif r.status_code == 204:
+        return []
+    else:
+        raise RuntimeError("{}: {}".format(r.url, r.status_code))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Populate Novo Nordisk database")
+    parser.add_argument("-t", "--threads",
+                        default=4,
+                        type=int,
+                        metavar="INT",
+                        help="number of threads querying the InterPro REST API (default: 4)")
+    parser.add_argument("--verbose", action="store_true", help="increase verbosity")
+    args = parser.parse_args()
+
+    if args.threads is not None and args.threads < 1:
+        parser.error("-t, --threads cannot be smaller than 1")
+    elif args.verbose:
+        logger.setLevel(logging.DEBUG)
+
+    for key in ("NND_HOST", "NND_USER", "NND_PASS", "NND_DB", "NND_PORT"):
+        try:
+            os.environ[key]
+        except KeyError:
+            parser.error("{}: no such environment variable".format(key))
+
+    try:
+        int(os.environ["NND_PORT"])
+    except ValueError:
+        parser.error("NND_PORT: integer expected")
+
+    logger.info("retrieving orthologs")
+    # 10090: Mus musculus, 10116: Rattus norvegicus
+    orthologs = fetch_orthologs((10090, 10116))
+
+    # Use `passwd` and `db` instead of `password` and `database` for for compatibility to MySQLdb
+    con = pymysql.connect(host=os.environ["NND_HOST"],
+                          user=os.environ["NND_USER"],
+                          passwd=os.environ["NND_PASS"],
+                          db=os.environ["NND_DB"],
+                          port=int(os.environ["NND_PORT"]))
+    cur = con.cursor()
+
+    logger.info("retrieving resources versions")
+    cur.executemany("INSERT INTO versions VALUES (%s, %s)",
+                    [("Complex portal", fetch_complex_version()),
+                    ("UniProtKB", fetch_uniprot_version()),
+                    ("KEGG", fetch_kegg_version()),
+                    ("Reactome", fetch_reactome_version()),
+                    ("InterPro", fetch_interpro_version())])
+
+    logger.info("retrieving Complex Portal data")
+    uniprot2complex = {}
+    for acc, name, cnt, identifers in fetch_complex_data():
+        cur.execute("INSERT INTO complex_portal VALUES (%s, %s, %s)",
+                        (acc, name, cnt))
+
+        for _id in identifers:
+            try:
+                uniprot2complex[_id].add(acc)
+            except KeyError:
+                uniprot2complex[_id] = {acc}
+
+    logger.info("retrieving Reactome data")
+    reactions = fetch_reactome_reactions(fetch_reactome_version())
+    cur.executemany("INSERT INTO reactome VALUES (%s, %s, %s, %s)",
+                    fetch_reactome_pathways(reactions))
+
+    logger.info("retrieving InterPro entries")
+    accessions = fetch_interpro_entries()
+    cnt = 0
+    with ThreadPoolExecutor(max_workers=args.threads) as executor:
+        for obj in executor.map(fetch_interpro_entry, accessions):
+            cur.execute("INSERT INTO interpro VALUES (%s, %s, %s, %s, %s, %s)", obj)
+
+            cnt += 1
+            if not cnt % 1000 or cnt == len(accessions):
+                logger.debug("\t{:>5} / {}".format(cnt, len(accessions)))
+
+    logger.info("retrieving UniProt entries")
+    cnt = 0
+    accessions = set()
+    for up in fetch_uniprot(9606):
+        accessions.add(up.accession)
+
+        # Overwrite cross-references to ComplexPortal with mappings from ComplexPortal
+        up.xrefs["ComplexPortal"] = uniprot2complex.get(up.accession, [])
+
+        cur.execute(
+            """
+            INSERT INTO protein
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            up.astuple()
+        )
+
+        for transcript_id, isoform in up.xrefs["Ensembl"]:
+            cur.execute("INSERT INTO ensembl_transcript VALUES (%s, %s, %s)",
+                        (up.accession, isoform, transcript_id))
+
+        for pathway_id, reaction_id, reaction_name, reaction_role in reactions.get(up.accession, []):
+            cur.execute("INSERT INTO reactome_step VALUES (%s, %s, %s, %s, %s)",
+                        (pathway_id, up.accession, reaction_id, reaction_name, reaction_role))
+
+        _orthologs = set()
+        for koid in up.xrefs["KO"]:
+            _orthologs |= set(orthologs.get(koid, []))
+
+        for orth_acc, orth_taxid in _orthologs:
+            cur.execute("INSERT INTO ortholog VALUES (%s, %s, %s)",
+                        (up.accession, orth_acc, orth_taxid))
+
+        for pdb_id, chain in up.xrefs["PDB"]:
+            cur.execute("INSERT INTO pdb VALUES (%s, %s, %s)",
+                        (up.accession, pdb_id, chain))
+
+        for go_id, go_class, go_name in up.xrefs["GO"]:
+            cur.execute("INSERT INTO gene_ontology VALUES (%s, %s, %s, %s)",
+                        (up.accession, go_id, go_class, go_name))
+
+        for complex_acc in up.xrefs["ComplexPortal"]:
+            try:
+                cur.execute("INSERT INTO complex_component VALUES (%s, %s)",
+                            (complex_acc, up.accession))
+            except pymysql.err.IntegrityError:
+                """
+                Jan 2020
+                Q6QNY1 has a reference to CPX-1912, which is not available in
+                the Complex Portal.
+                """
+                logger.warning("invalid mapping: {} <-> {}".format(complex_acc, up.accession))
+
+        cnt += 1
+        if not cnt % 10000:
+            logger.debug("\t{:>6}".format(cnt))
+    logger.debug("\t{:>6}".format(cnt))
+
+    logger.info("retrieving KEGG data")
+    for pathway_id, pathway_desc, num_steps, disease, steps in fetch_kegg_data():
+        cur.execute("INSERT INTO kegg VALUES (%s, %s, %s, %s)",
+                    (pathway_id, pathway_desc, num_steps, disease))
+
+        for uniprot_acc, hsa, gene, desc in steps:
+            try:
+                cur.execute("INSERT INTO kegg_step VALUES (%s, %s, %s, %s, %s)",
+                            (pathway_id, uniprot_acc, hsa, gene, desc))
+            except pymysql.err.IntegrityError:
+                logger.warning("invalid mapping: {} <-> {}".format(pathway_id, uniprot_acc))
+
+    logger.info("retrieving InterPro matches")
+    with ThreadPoolExecutor(max_workers=args.threads) as executor:
+        fs = {}
+        for uniprot_acc in accessions:
+            f = executor.submit(fetch_interpro_matches, uniprot_acc)
+            fs[f] = uniprot_acc
+
+        cnt = 0
+        total = len(fs)
+        while fs:
+            failed = []
+            for f in as_completed(fs):
+                try:
+                    entries = f.result()
+                except Exception as exc:
+                    # logger.debug("\terror: {}".format(exc))
+                    failed.append(fs[f])
+                else:
+                    for interpro_acc, locations in entries:
+                        for start, end in locations:
+                            cur.execute("INSERT INTO interpro_match VALUES (%s, %s, %s, %s)",
+                                        (interpro_acc, fs[f], start, end))
+
+                    cnt += 1
+                    if not cnt % 10000:
+                        logger.debug("\t{:>6} / {}".format(cnt, total))
+
+            fs = {}
+            for uniprot_acc in failed:
+                f = executor.submit(fetch_interpro_matches, uniprot_acc)
+                fs[f] = uniprot_acc
+        logger.debug("\t{:>6} / {}".format(cnt, total))
+
+    con.commit()
+    cur.close()
+    con.close()
+
+    logger.info("complete")
+
+
+if __name__ == '__main__':
+    main()

--- a/python/populate.py
+++ b/python/populate.py
@@ -20,7 +20,6 @@ import pymysql
 # - IPRs with multiple children (only one taken at present) - check query
 # - kegg_step via API - streamline?
 # - target - populate acc/source, possibly from second script
-# - reactome version
 # - auto generate schema?
 
 
@@ -360,12 +359,17 @@ for line in kegg_info:
     kegg_version = m.group(1)
     break
 
+reactome_version = urllib.request.urlopen("https://reactome.org/ContentService/data/database/version").read().decode("utf-8").strip()
+interpro_version = urllib.request.urlopen("https://www.ebi.ac.uk/interpro/api/").info()["InterPro-Version"].strip()
+
 with nnd_conn.cursor() as cursor:
   version_sql = insert_sql('versions', version_columns())
   cursor.execute('delete from versions')
   cursor.execute(version_sql, ('Complex portal', cp_version))
   cursor.execute(version_sql, ('UniProtKB', ukb_version))
   cursor.execute(version_sql, ('KEGG', kegg_version))
+  cursor.execute(version_sql, ('Reactome', reactome_version))
+  cursor.execute(version_sql, ('InterPro', interpro_version))
   nnd_conn.commit()
 
 # Pull orthologs and reactome reactions now as it's quicker to get for
@@ -386,8 +390,6 @@ for orth_species in [10090, 10116]:
 
 reactions = {}
 reactome_steps = {}
-reactome_version = urllib.request.urlopen("https://reactome.org/ContentService/data/database/version").read().decode("utf-8").strip()
-
 with urllib.request.urlopen("https://reactome.org/download/current/reactome_reaction_exporter_v{}.txt".format(reactome_version)) as res:
     next(res) # Skip header
 


### PR DESCRIPTION
The code in the `master` branch relies on a local file (`reactome_reaction_exporter.txt`) to populate the `reactome_step` table.  Since then, the Reactome team updated their production procedures to generate this file every release and make it available on their website.

The Python script has been largely rewritten to address various issues, e.g.:
- adding the InterPro and Reactome versions to the `versions` table;
- performance issues caused by calling the KEGG REST API twice per protein (in order to get the KEGG-UniProt mapping);
- performance issues when retrieving InterPro matches.

A minimalistic documentation has been added to the README file.